### PR TITLE
Add pitch text box and put note markings on the left.

### DIFF
--- a/Assets/ThereminQuestVR/Scenes/Theremin Skybox.unity
+++ b/Assets/ThereminQuestVR/Scenes/Theremin Skybox.unity
@@ -329,14 +329,14 @@ MonoBehaviour:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 14
     m_FontStyle: 0
-    m_BestFit: 0
+    m_BestFit: 1
     m_MinSize: 10
     m_MaxSize: 40
     m_Alignment: 0
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
   m_Text: 'Pitch:'
 --- !u!222 &910504856

--- a/Assets/ThereminQuestVR/Scenes/Theremin Skybox.unity
+++ b/Assets/ThereminQuestVR/Scenes/Theremin Skybox.unity
@@ -459,7 +459,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4293780271772404, guid: 006d590cc72f50a47ace793b80eb5ae7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 1.1
       objectReference: {fileID: 0}
     - target: {fileID: 82378719202824134, guid: 006d590cc72f50a47ace793b80eb5ae7,
         type: 3}
@@ -481,6 +481,11 @@ PrefabInstance:
       propertyPath: pitchText
       value: 
       objectReference: {fileID: 910504855}
+    - target: {fileID: 114236053965648702, guid: 006d590cc72f50a47ace793b80eb5ae7,
+        type: 3}
+      propertyPath: pitchSensitivity
+      value: 8
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 006d590cc72f50a47ace793b80eb5ae7, type: 3}
 --- !u!20 &1317019043 stripped

--- a/Assets/ThereminQuestVR/Scripts/Oscillator.cs
+++ b/Assets/ThereminQuestVR/Scripts/Oscillator.cs
@@ -89,7 +89,7 @@ namespace ThereminQuestVR {
                 }
 
                 if (distance > 0) {
-                    markers[i].transform.localPosition = pitchAntenna.transform.localPosition + Vector3.left * distance;
+                    markers[i].transform.localPosition = pitchAntenna.transform.localPosition + Vector3.right * distance;
                 } else {
                     markers[i].transform.localPosition = pitchAntenna.transform.localPosition;
                 }

--- a/Assets/ThereminQuestVR/Scripts/Oscillator.cs
+++ b/Assets/ThereminQuestVR/Scripts/Oscillator.cs
@@ -37,6 +37,11 @@ namespace ThereminQuestVR {
         private readonly Vector3 blackKeyScale = new Vector3(1, 0.5f, 1);
         private readonly float frequencyRatio = Mathf.Pow(2, 1.0f / 12.0f);
 
+        private static readonly float A4 = 440.0f;
+        private static readonly float C0 = A4 * Mathf.Pow(2, -4.75f);
+        private static readonly string[] notes = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+        private static readonly int NUM_NOTES = 12;
+
         void Start() {
 			
             // Launch coroutines to mark both hands as detected.
@@ -71,7 +76,7 @@ namespace ThereminQuestVR {
 
             pitch = GetPitch();
             audioSource.pitch = pitch;
-            pitchText.text = "Pitch: " + pitch;
+            UpdatePitchUI(pitch);
 
             for (int i = 0; i < markers.Length; i++) {
                 float a = (Mathf.Pow(frequencyRatio, i - markerRange) - pitchMin) / (pitchMax - pitchMin);
@@ -105,6 +110,16 @@ namespace ThereminQuestVR {
                 pitchHandDistance = sumDistances / pitchHand.Bones.Count;
             }
             return Mathf.Exp(-pitchHandDistance * pitchSensitivity) * (pitchMax - pitchMin) + pitchMin;
+        }
+        
+        void UpdatePitchUI(float pitch) {
+            // Calculate the frequency from the pitch.
+            float freq = A4 * pitch;
+            // get number of half steps from C0
+            int numHalfSteps = Mathf.RoundToInt(NUM_NOTES * Mathf.Log(freq/C0, 2));
+            int octave = numHalfSteps / NUM_NOTES;
+            int note = numHalfSteps % NUM_NOTES;
+            pitchText.text = string.Format("Pitch: {0:0.00}, Frequency: {1:0}Hz, Nearest Note: {2}{3}", pitch, freq, notes[note], octave);
         }
 		
         float HorizontalDistance(Vector3 v1, Vector3 v2) {

--- a/Assets/ThereminQuestVR/Scripts/Oscillator.cs
+++ b/Assets/ThereminQuestVR/Scripts/Oscillator.cs
@@ -126,8 +126,8 @@ namespace ThereminQuestVR {
             return Vector2.Distance(new Vector2(v1.x, v1.z), new Vector2(v2.x, v2.z));
         }
 		
-        float AverageHorizontalDistance() {
-            // return average horizontal distance of all fingers on the pitch hand.
+        float Top3AverageHorizontalDistance() {
+            // return average horizontal distance of the 3 closest fingers to the pitch control.
             // TODO
             return 0f;
             


### PR DESCRIPTION
* Pitch text box displays the pitch, frequency, and nearest note.
* Place note markings on the left, which should be the proper position when playing theremin.
* Adjust pitch senstivity from 10 to 8 to make it easier to hit the target frequency.