### PR TITLE
Only consider the K closest finger bones when calculating pitch.

### DIFF
--- a/Assets/ThereminQuestVR/Scenes/Theremin Skybox.unity
+++ b/Assets/ThereminQuestVR/Scenes/Theremin Skybox.unity
@@ -486,6 +486,11 @@ PrefabInstance:
       propertyPath: pitchSensitivity
       value: 8
       objectReference: {fileID: 0}
+    - target: {fileID: 114236053965648702, guid: 006d590cc72f50a47ace793b80eb5ae7,
+        type: 3}
+      propertyPath: numBonesToIncludeInAverage
+      value: 9
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 006d590cc72f50a47ace793b80eb5ae7, type: 3}
 --- !u!20 &1317019043 stripped


### PR DESCRIPTION
Instead of calculating the average distance between the entire hand and the pitch control, only consider the K closest bones.
Theremin players often use the middle, ring and pinky to do octave jumps. So taking average of entire hand means thumb and index fingers "drag" the average backwards greatly and makes octave jumps very hard without having to shift the entire hand.

I find that `K = 9` (average distance of 3 fingers x 3 joints per finger) to be the most comfortable to use.

See diagram:

![alt text](https://static.wixstatic.com/media/d6c52d_8b91652fb6aa4c1dbcfe011720d75b6d~mv2_d_3246_6147_s_4_2.jpg/v1/fill/w_143,h_431,al_c,q_80,usm_0.66_1.00_0.01/d6c52d_8b91652fb6aa4c1dbcfe011720d75b6d~mv2_d_3246_6147_s_4_2.webp "Theremin Hand Positions")

I'm using an one pass insertion sort based algorithm to find the K closest bones. I also considered using a sort, quickselect, or min-heap to get better asymptotic runtime. But since K and N are bounded to be quite small I felt that simple linear scans on an array would be faster in practice.